### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dansguardian (2.10.1.1-6) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 16:18:48 +0100
+
 dansguardian (2.10.1.1-5) unstable; urgency=low
 
   * [0a5a03b] Add support for "status" action to init.d script.

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: autotools-dev,
                zlib1g-dev
 Standards-Version: 3.9.2
 Vcs-Browser: https://github.com/formorer/pkg-dansguardian
-Vcs-Git: git://github.com/formorer/pkg-dansguardian.git
+Vcs-Git: https://github.com/formorer/pkg-dansguardian.git
 
 Package: dansguardian
 Architecture: any


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
